### PR TITLE
add: use presigned POST to enforce file size and Content-Type via S3 conditions

### DIFF
--- a/aws/s3-presigned-url/README.md
+++ b/aws/s3-presigned-url/README.md
@@ -62,12 +62,48 @@ docker compose up --build
 
 | Method | Path | 概要 |
 | --- | --- | --- |
-| POST | `/api/prepare` | 一時バケットの `/{uuid}` に対するアップロード用 Pre-signed URL (PUT, 15分) を発行 |
+| POST | `/api/prepare` | 一時バケットの `/{uuid}` に対するアップロード用 Pre-signed **POST** (`PresignPostObject`, 15分) を発行。フォーム用の `uploadUrl` と `fields`（`key` / `policy` / `X-Amz-*` など）を返す |
 | POST | `/api/commit` | uuid ごとに PDF かどうかを検証したうえで一時バケット→登録済みバケットへ Copy し、成功したものは一時バケットから Delete (=move) |
 | GET | `/api/file-list` | 登録済みバケットの一覧と、各ファイルのダウンロード用 Pre-signed URL (GET, 15分) を返す |
 
 `commit` はファイル種別を PDF に限定している。判定はファイル全体を読み込まず、一時バケットのオブジェクトに対して `Range: bytes=0-4` を指定した `GetObject` でマジックナンバー (`%PDF-`) の 5 バイトだけを取得して行う。結果は `results[].status` に `committed` / `not_found` / `invalid_file_type` / `error` のいずれかで返る。
 
+## Pre-signed POST によるファイルサイズ / MIME type の制御
+
+`prepare` は `PresignPutObject`（PUT 用の単純な署名 URL）ではなく `PresignPostObject` を使い、ブラウザから直接 `multipart/form-data` で S3 (floci) に POST させる方式に変更した。`PresignPostOptions.Conditions` に以下の 2 条件を付与しており、これらは返却される `fields.policy`（Base64 エンコードされた JSON）に埋め込まれ、`fields["X-Amz-Signature"]` はこのポリシー文書に対して署名される。
+
+```go
+o.Conditions = []any{
+    []any{"content-length-range", 0, 500 * 1024}, // 0〜500KB
+    map[string]string{"Content-Type": "application/pdf"},
+}
+```
+
+デコードすると次のような `policy` になる（`bucket` / `X-Amz-*` / `key` は SDK が自動付与するもの）。
+
+```json
+{
+  "conditions": [
+    { "X-Amz-Algorithm": "AWS4-HMAC-SHA256" },
+    { "bucket": "presigned-tmp" },
+    { "X-Amz-Credential": "..." },
+    { "X-Amz-Date": "..." },
+    ["content-length-range", 0, 512000],
+    { "Content-Type": "application/pdf" },
+    { "key": "..." }
+  ],
+  "expiration": "..."
+}
+```
+
+フロントエンド (`api.ts`) は `fields` をそのまま `FormData` に詰め、実際に選択されたファイルの `file.type` を `Content-Type` フィールドとして追加し（S3 の POST ポリシー仕様に合わせて `file` フィールドを最後に追加）、`uploadUrl` へ POST する。仕様上 S3 は POST リクエストがこのポリシーの条件を満たさない場合（サイズ超過 / `Content-Type` 不一致）、オブジェクトを作成せず `4xx` を返す。
+
+この構成により、**ファイルサイズと MIME type の制御を、アプリケーションサーバーを経由せずブラウザ→S3 の直接アップロード時点で行える**ことを確認した（少なくとも Pre-signed POST の署名対象ポリシーとしては正しく構築できている。実機での動作は下記「floci に関する制約」を参照）。
+
+ただし `Content-Type` 条件はあくまで **クライアントが送ってきたフォームフィールドの値との一致** を見ているだけで、ファイルの中身までは検証しない。そのため画像ファイルの拡張子・Content-Type を `application/pdf` と偽って送れば、この条件だけではすり抜けてしまう。`commit` 時点でのマジックナンバー検証（ファイル先頭バイトの実データ確認）は、この抜け道に対する二段目のチェックとして引き続き必要であり、削除せず残している。
+
 ## floci に関する制約
 
 動作確認の結果、floci は Pre-signed URL の **有効期限 (`X-Amz-Expires`) は検証するが、署名 (`X-Amz-Signature`) 自体は検証しない**（署名を改ざんしても、あるいは全く付与しなくてもリクエストが成功する）。そのため、このプロトタイプでは Pre-signed URL の基本的な発行〜利用の流れと有効期限切れの挙動は確認できるが、署名改ざん・不正な認証情報によるリクエスト拒否といった署名検証まわりの挙動は確認できない。
+
+Pre-signed POST の `content-length-range` / `Content-Type` 条件についても、floci が実際にポリシーを評価して拒否するかどうかは本リポジトリの CI 環境では確認できていない（Docker Hub からのイメージ取得がネットワークポリシーでブロックされており、`docker compose up` を実行できなかったため）。ローカル環境で `docker compose up --build` を実行し、500KB超のファイルや PDF 以外のファイル（`Content-Type` を偽らない場合）をアップロードして、S3 (floci) 側で拒否されるかどうかを実際に確認することを推奨する。

--- a/aws/s3-presigned-url/backend/internal/handler/handler.go
+++ b/aws/s3-presigned-url/backend/internal/handler/handler.go
@@ -25,7 +25,17 @@ import (
 
 const presignExpiry = 15 * time.Minute
 
-// pdfMagicNumber is the byte sequence every PDF file starts with.
+// maxUploadBytes and allowedContentType are enforced up front via the
+// pre-signed POST policy conditions (content-length-range / Content-Type),
+// so S3 itself rejects an oversized or wrong-type upload before the object
+// is even written to the tmp bucket.
+const maxUploadBytes = 500 * 1024 // 500KB
+const allowedContentType = "application/pdf"
+
+// pdfMagicNumber is the byte sequence every PDF file starts with. Commit
+// still checks this because the POST policy's Content-Type condition only
+// constrains the *declared* form field, which the client controls and can
+// lie about; this is the check against the actual file bytes.
 var pdfMagicNumber = []byte("%PDF-")
 
 type Handler struct {
@@ -44,8 +54,9 @@ type prepareRequest struct {
 }
 
 type prepareResponse struct {
-	UUID      string `json:"uuid"`
-	UploadURL string `json:"uploadUrl"`
+	UUID      string            `json:"uuid"`
+	UploadURL string            `json:"uploadUrl"`
+	Fields    map[string]string `json:"fields"`
 }
 
 func (h *Handler) Prepare(w http.ResponseWriter, r *http.Request) {
@@ -61,12 +72,18 @@ func (h *Handler) Prepare(w http.ResponseWriter, r *http.Request) {
 
 	id := uuid.NewString()
 
-	out, err := h.s3.Presign.PresignPutObject(r.Context(), &s3.PutObjectInput{
+	out, err := h.s3.Presign.PresignPostObject(r.Context(), &s3.PutObjectInput{
 		Bucket: aws.String(h.cfg.TmpBucket),
 		Key:    aws.String(id),
-	}, s3.WithPresignExpires(presignExpiry))
+	}, func(o *s3.PresignPostOptions) {
+		o.Expires = presignExpiry
+		o.Conditions = []any{
+			[]any{"content-length-range", 0, maxUploadBytes},
+			map[string]string{"Content-Type": allowedContentType},
+		}
+	})
 	if err != nil {
-		log.Printf("presign put object failed: %v", err)
+		log.Printf("presign post object failed: %v", err)
 		writeError(w, http.StatusInternalServerError, "failed to create upload URL")
 		return
 	}
@@ -74,6 +91,7 @@ func (h *Handler) Prepare(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, prepareResponse{
 		UUID:      id,
 		UploadURL: out.URL,
+		Fields:    out.Values,
 	})
 }
 

--- a/aws/s3-presigned-url/frontend/src/api.ts
+++ b/aws/s3-presigned-url/frontend/src/api.ts
@@ -3,6 +3,7 @@ const API_BASE_URL: string = import.meta.env.VITE_API_BASE_URL ?? "http://localh
 export interface PrepareResponse {
   uuid: string;
   uploadUrl: string;
+  fields: Record<string, string>;
 }
 
 export interface CommitFileInput {
@@ -48,13 +49,30 @@ export function prepareUpload(fileName: string): Promise<PrepareResponse> {
   });
 }
 
-export async function uploadToPresignedUrl(uploadUrl: string, file: File): Promise<void> {
+export async function uploadToPresignedUrl(
+  uploadUrl: string,
+  fields: Record<string, string>,
+  file: File
+): Promise<void> {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    formData.append(key, value);
+  }
+  // The Content-Type field is matched against the pre-signed POST policy's
+  // condition (fixed to application/pdf), so the browser-detected MIME type
+  // is sent as-is instead of being overridden — a non-PDF selection should
+  // be rejected by S3 itself rather than silently coerced to pass.
+  formData.append("Content-Type", file.type);
+  // The file field must come last, per the S3 POST policy form requirements.
+  formData.append("file", file);
+
   const res = await fetch(uploadUrl, {
-    method: "PUT",
-    body: file,
+    method: "POST",
+    body: formData,
   });
   if (!res.ok) {
-    throw new Error(`upload failed: ${res.status} ${res.statusText}`);
+    const body = await res.text();
+    throw new Error(`upload failed: ${res.status} ${res.statusText} ${body}`);
   }
 }
 

--- a/aws/s3-presigned-url/frontend/src/main.ts
+++ b/aws/s3-presigned-url/frontend/src/main.ts
@@ -91,8 +91,8 @@ async function onFilesSelected(e: Event): Promise<void> {
 async function uploadOne(item: UploadItem, index: number, generation: number): Promise<void> {
   let updated: UploadItem;
   try {
-    const { uuid, uploadUrl } = await prepareUpload(item.file.name);
-    await uploadToPresignedUrl(uploadUrl, item.file);
+    const { uuid, uploadUrl, fields } = await prepareUpload(item.file.name);
+    await uploadToPresignedUrl(uploadUrl, fields, item.file);
     updated = { ...item, uuid, status: "done" };
   } catch (err) {
     updated = {

--- a/aws/s3-presigned-url/scripts/setup-buckets.sh
+++ b/aws/s3-presigned-url/scripts/setup-buckets.sh
@@ -26,7 +26,7 @@ cat <<EOF >/tmp/cors.json
   "CORSRules": [
     {
       "AllowedOrigins": ["${ALLOWED_ORIGIN}"],
-      "AllowedMethods": ["PUT", "GET"],
+      "AllowedMethods": ["PUT", "POST", "GET"],
       "AllowedHeaders": ["*"],
       "ExposeHeaders": ["ETag"]
     }
@@ -34,8 +34,8 @@ cat <<EOF >/tmp/cors.json
 }
 EOF
 
-# The tmp bucket needs CORS so the browser can PUT directly to a presigned
-# URL from the frontend's origin. The store bucket gets the same rule so
+# The tmp bucket needs CORS so the browser can POST directly to a presigned
+# POST URL from the frontend's origin. The store bucket gets the same rule so
 # fetch-based downloads of presigned GET URLs would also work, even though
 # the file-list page currently only uses plain <a> navigation.
 aws s3api put-bucket-cors --bucket "${TMP_BUCKET}" --cors-configuration file:///tmp/cors.json --endpoint-url "${ENDPOINT}"


### PR DESCRIPTION
Switches /api/prepare from PresignPutObject to PresignPostObject with
content-length-range (0-500KB) and Content-Type (application/pdf)
policy conditions, so S3 rejects out-of-bounds uploads before they
land in the tmp bucket. Frontend now uploads via multipart form POST
using the returned presigned fields instead of a raw PUT.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014WWvxtrP1HWJ8G2tjwFc4v