### PR TITLE
Update port numbers to avoid conflicts with common services

### DIFF
--- a/aws/s3-presigned-url/README.md
+++ b/aws/s3-presigned-url/README.md
@@ -12,21 +12,21 @@ Amazon S3 の Pre-signed URL の挙動を確認するためのプロトタイプ
 ```
 ┌────────────┐   POST /api/prepare    ┌─────────┐
 │  frontend  │ ─────────────────────▶ │ backend │
-│ (:5174)    │ ◀───────────────────── │ (:8080) │
+│ (:55174)   │ ◀───────────────────── │ (:58080)│
 └─────┬──────┘   { uuid, uploadUrl }  └────┬────┘
       │                                    │ internal S3 calls
       │ PUT (direct upload)                │ (Copy/Delete/List)
       ▼                                    ▼
 ┌─────────────────────────────────────────────────┐
-│                 floci (:4566)                    │
+│                 floci (:54566)                   │
 │   presigned-tmp/{uuid}  →  presigned-store/{uuid}/{fileName}
 └─────────────────────────────────────────────────┘
 ```
 
 Pre-signed URL はブラウザに渡されるため、backend は 2 つの S3 クライアントを使い分けている。
 
-- `S3_INTERNAL_ENDPOINT` (`http://floci:4566`) — docker-compose 内部からの Copy/Delete/List に使用
-- `S3_PUBLIC_ENDPOINT` (`http://localhost:4566`) — Pre-signed URL の署名対象ホストに使用（ブラウザから解決可能なアドレスである必要がある）
+- `S3_INTERNAL_ENDPOINT` (`http://floci:4566`) — docker-compose 内部からの Copy/Delete/List に使用（コンテナ間通信のためホスト公開ポートとは独立）
+- `S3_PUBLIC_ENDPOINT` (`http://localhost:54566`) — Pre-signed URL の署名対象ホストに使用（ブラウザから解決可能なアドレスである必要がある）
 
 ## 起動方法
 
@@ -34,7 +34,7 @@ Pre-signed URL はブラウザに渡されるため、backend は 2 つの S3 �
 
 1. VS Code でこのディレクトリ (`aws/s3-presigned-url`) を開き、"Reopen in Container" を実行する
 2. `docker compose up` 相当の処理が自動的に走り、floci / バケット作成 / backend / frontend が起動する
-3. ブラウザで http://localhost:5174 を開く
+3. ブラウザで http://localhost:55174 を開く
 
 ### devcontainer を使わず直接起動する場合
 
@@ -46,9 +46,11 @@ docker compose up --build
 
 | サービス | URL | 用途 |
 | --- | --- | --- |
-| frontend | http://localhost:5174 | アップロード / ファイル一覧 UI |
-| backend | http://localhost:8080 | API |
-| floci (S3) | http://localhost:4566 | S3 互換 API |
+| frontend | http://localhost:55174 | アップロード / ファイル一覧 UI |
+| backend | http://localhost:58080 | API |
+| floci (S3) | http://localhost:54566 | S3 互換 API |
+
+ホストマシン上で他プロセスとポートが競合しないよう、ポートは一般的に使われにくい番号（49152–65535 の動的/私用ポート範囲）を割り当てている。
 
 停止する場合は `docker compose down`。
 

--- a/aws/s3-presigned-url/backend/internal/config/config.go
+++ b/aws/s3-presigned-url/backend/internal/config/config.go
@@ -29,7 +29,7 @@ func Load() (Config, error) {
 		AWSRegion:          getEnv("AWS_REGION", "us-east-1"),
 		TmpBucket:          os.Getenv("S3_TMP_BUCKET"),
 		StoreBucket:        os.Getenv("S3_STORE_BUCKET"),
-		AllowedOrigin:      getEnv("ALLOWED_ORIGIN", "http://localhost:5173"),
+		AllowedOrigin:      getEnv("ALLOWED_ORIGIN", "http://localhost:55174"),
 	}
 
 	var missing []string

--- a/aws/s3-presigned-url/docker-compose.yml
+++ b/aws/s3-presigned-url/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   floci:
     image: floci/floci:latest
     ports:
-      - "4566:4566"
+      - "54566:4566"
 
   bucket-setup:
     image: amazon/aws-cli:2.36.23
@@ -16,25 +16,25 @@ services:
       S3_ENDPOINT: http://floci:4566
       S3_TMP_BUCKET: presigned-tmp
       S3_STORE_BUCKET: presigned-store
-      ALLOWED_ORIGIN: http://localhost:5174
+      ALLOWED_ORIGIN: http://localhost:55174
     volumes:
       - ./scripts:/scripts:ro
 
   backend:
     build: ./backend
     ports:
-      - "8080:8080"
+      - "58080:8080"
     depends_on:
       bucket-setup:
         condition: service_completed_successfully
     environment:
       PORT: 8080
       S3_INTERNAL_ENDPOINT: http://floci:4566
-      S3_PUBLIC_ENDPOINT: http://localhost:4566
+      S3_PUBLIC_ENDPOINT: http://localhost:54566
       AWS_REGION: us-east-1
       S3_TMP_BUCKET: presigned-tmp
       S3_STORE_BUCKET: presigned-store
-      ALLOWED_ORIGIN: http://localhost:5174
+      ALLOWED_ORIGIN: http://localhost:55174
       AWS_ACCESS_KEY_ID: test
       AWS_SECRET_ACCESS_KEY: test
     volumes:
@@ -43,11 +43,11 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "5174:5173"
+      - "55174:5173"
     depends_on:
       - backend
     environment:
-      VITE_API_BASE_URL: http://localhost:8080
+      VITE_API_BASE_URL: http://localhost:58080
     volumes:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules

--- a/aws/s3-presigned-url/frontend/src/api.ts
+++ b/aws/s3-presigned-url/frontend/src/api.ts
@@ -1,4 +1,4 @@
-const API_BASE_URL: string = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080";
+const API_BASE_URL: string = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:58080";
 
 export interface PrepareResponse {
   uuid: string;


### PR DESCRIPTION
## Summary
Updated all port numbers in the S3 presigned URL prototype to use the dynamic/private port range (49152–65535) to avoid conflicts with other services running on the host machine.

## Key Changes
- **Frontend**: Changed from port 5174 to 55174
- **Backend**: Changed from port 8080 to 58080
- **LocalStack (floci)**: Changed from port 4566 to 54566
- Updated all references across configuration files, environment variables, and documentation
- Added clarification in README explaining the rationale for using dynamic/private port range

## Files Modified
- `docker-compose.yml`: Updated all port mappings and environment variables
- `README.md`: Updated service URLs and added explanation for port selection
- `backend/internal/config/config.go`: Updated default ALLOWED_ORIGIN
- `frontend/src/api.ts`: Updated default API_BASE_URL

## Implementation Details
- The internal S3 endpoint (`http://floci:4566`) remains unchanged as it uses container-to-container communication
- The public S3 endpoint for presigned URLs now uses the new port (54566) to match the host-exposed port
- All CORS and API configuration updated to reflect the new port numbers
- Changes maintain backward compatibility with devcontainer setup

https://claude.ai/code/session_013RYzz8VuqKVWMs8Eh77V7X